### PR TITLE
add run SynthSeg command and generic command

### DIFF
--- a/brainvisa/toolboxes/freesurfer/hierarchies/brainvisa-3.2.0/synthseg.py
+++ b/brainvisa/toolboxes/freesurfer/hierarchies/brainvisa-3.2.0/synthseg.py
@@ -1,0 +1,20 @@
+include('base')
+#include('anatomy')
+
+insert('{center}/{subject}',
+    "synthSeg", SetWeakAttr("modality", "synthSeg"), SetContent(
+        "{acquisition}",
+        SetType("Acquisition"),
+        SetDefaultAttributeValue("acquisition", default_acquisition),
+        SetContent(
+            "<subject>_segmentation", SetType("SynthSeg segmentation"),
+            "<subject>_parcellation", SetType("SynthSeg parcellation"),
+            "<subject>_volumes", SetType("SynthSeg volumes"),
+            "<subject>_qc", SetType("QC Table"),
+            "<subject>_posterior", SetType("Tissue probability map"),
+            "<subject>_resampled", SetType("SynthSeg resampled"),
+            "<subject>_report", SetType("Analysis Report"),
+            "<subject>_execution", SetType("SynthSeg execution log"),
+        ),
+    ),
+)

--- a/brainvisa/toolboxes/freesurfer/processes/Tools/RunSynthSeg.procdoc
+++ b/brainvisa/toolboxes/freesurfer/processes/Tools/RunSynthSeg.procdoc
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<minf expander="minf_2.0">
+<d>
+  <d name="en">
+    <xhtml name="short">This process runs <b>SynthSeg</b> (https://github.com/BBillot/SynthSeg) to segment MRI data. SynthSeg is a deep learning-based brain segmentation tool that performs whole-brain segmentation and optionally cortical parcellation.</xhtml>
+    <xhtml name="long">SynthSeg is a robust brain segmentation tool that can segment MRI scans of any contrast and resolution, without retraining or fine-tuning. It uses a deep learning model trained on synthetic data to generalize to real scans. The process accepts Raw T1 MRI in NIfTI format and produces segmentation outputs organized in the subject folder structure.</xhtml>
+    <d name="parameters">
+      <xhtml name="t1mri">Raw T1 MRI scan to be segmented. Must be in NIfTI format (.nii or .nii.gz).</xhtml>
+      <xhtml name="output_folder">Output folder for SynthSeg results, organized according to BrainVISA database hierarchy with modality "synthseg".</xhtml>
+      <xhtml name="segmentation">Output segmentation volume containing brain structures labels.</xhtml>
+
+      <xhtml name="volumes_csv">Optional CSV file to save volumes for all segmented regions.</xhtml>
+      <xhtml name="qc_csv">Optional CSV file to save quality control scores.</xhtml>
+      <xhtml name="posterior">Optional output for 3D posterior probabilities.</xhtml>
+      <xhtml name="resampled">Optional output to save resampled images at 1mm resolution.</xhtml>
+      <xhtml name="execution_log">Optional JSON file to save execution log with all parameters, inputs, outputs, and command used.</xhtml>
+
+      <xhtml name="parc">Perform cortical parcellation in addition to whole-brain segmentation.</xhtml>
+      <xhtml name="robust">Use the variant for increased robustness (slower but better for clinical data with large slice spacing).</xhtml>
+      <xhtml name="fast">Disable some postprocessing for faster prediction (approximately twice as fast, slightly less accurate). Not compatible with --robust.</xhtml>
+      <xhtml name="crop">Crop the inputs to a given shape before segmentation (must be divisible by 32). Can be a single integer or multiple integers in RAS coordinates (e.g., "160" or "160 128 192").</xhtml>
+      <xhtml name="threads">Number of threads to be used by Tensorflow (default: 1). Increase to decrease runtime when using CPU version.</xhtml>
+      <xhtml name="cpu">Run on CPU rather than GPU.</xhtml>
+      <xhtml name="v1">Use the first version of SynthSeg (SynthSeg 1.0).</xhtml>
+      <xhtml name="overwrite">Allow overwriting of existing output directory if it already contains SynthSeg results.</xhtml>
+    </d>
+  </d>
+</d>
+</minf>

--- a/brainvisa/toolboxes/freesurfer/processes/Tools/RunSynthSeg.py
+++ b/brainvisa/toolboxes/freesurfer/processes/Tools/RunSynthSeg.py
@@ -113,10 +113,10 @@ def execution(self, context):
             os.makedirs(output_dir, exist_ok=True)
         else:
             context.error(
-                f"Output directory '{output_dir}' is not empty. SynthSeg has already been launched for this subjet and timepoint. "
-                "Please remove these results or choose overwrtie option to do so."
+                f"Output directory '{output_dir}' is not empty. SynthSeg has already been launched for this subject and timepoint. "
+                "Please remove these results or choose the overwrite option to do so."
             )
-            raise AttributeError()
+            raise RuntimeError(f"Output directory '{output_dir}' is not empty.")
 
     context.runProcess(
         "RunSynthSeg_generic",

--- a/brainvisa/toolboxes/freesurfer/processes/Tools/RunSynthSeg.py
+++ b/brainvisa/toolboxes/freesurfer/processes/Tools/RunSynthSeg.py
@@ -1,0 +1,139 @@
+import os
+import shutil
+
+from brainvisa.processes import Boolean, Integer, ReadDiskItem, Signature, String, WriteDiskItem
+from freesurfer.brainvisaFreesurfer import testFreesurferCommand
+
+name = "Run SynthSeg"
+userLevel = 1
+
+synthseg_options = "SynthSeg options"
+optional_outputs = "Optional outputs"
+
+default_format = ["gz compressed NIFTI-1 image", "NIFTI-1 image"]
+
+# fmt: off
+signature = Signature(
+    # Input
+    "t1mri", ReadDiskItem("Raw T1 MRI", default_format),
+
+    # Output folder
+    "output_folder", WriteDiskItem("Acquisition", "Directory", requiredAttributes={"modality": "synthSeg"}),
+
+    # Main output
+    "segmentation", WriteDiskItem("SynthSeg segmentation", default_format,
+                                  requiredAttributes={"modality": "synthSeg"}),
+
+    # Optional outputs
+    "volumes_csv", WriteDiskItem("SynthSeg volumes", "CSV file", section=optional_outputs,
+                                 requiredAttributes={"modality": "synthSeg"}),
+    "qc_csv", WriteDiskItem("QC Table", "CSV file", section=optional_outputs,
+                            requiredAttributes={"modality": "synthSeg"}),
+    "posterior", WriteDiskItem("Tissue probability map", default_format,
+                               section=optional_outputs, requiredAttributes={"modality": "synthSeg"}),
+    "resampled", WriteDiskItem("SynthSeg resampled", default_format,
+                               section=optional_outputs, requiredAttributes={"modality": "synthSeg"}),
+    "execution_log", WriteDiskItem("SynthSeg execution log", "JSON file", section=optional_outputs,
+                                   requiredAttributes={"modality": "synthSeg"}),
+
+    # SynthSeg options
+    "parc", Boolean(section=synthseg_options),
+    "robust", Boolean(section=synthseg_options),
+    "fast", Boolean(section=synthseg_options),
+    "crop", String(section=synthseg_options),
+    "threads", Integer(section=synthseg_options),
+    "cpu", Boolean(section=synthseg_options),
+    "v1", Boolean(section=synthseg_options),
+    "overwrite", Boolean(section=synthseg_options)
+)
+# fmt: on
+
+
+def validation():
+    testFreesurferCommand()
+
+
+def initialization(self):
+    # Set defaults matching SynthSeg
+    self.threads = 1
+    self.cpu = False
+    self.robust = False
+    self.fast = False
+    self.parc = False
+    self.v1 = False
+    self.overwrite = False
+
+    # Make optional outputs optional
+    self.setOptional("volumes_csv", "qc_csv", "posterior", "resampled", "crop")
+
+    # Link outputs to folder
+    self.addLink("output_folder", "t1mri")
+    self.addLink("segmentation", "output_folder", self.update_output)
+    self.addLink("volumes_csv", "output_folder")
+    self.addLink("qc_csv", "output_folder")
+    self.addLink("posterior", "output_folder")
+    self.addLink("resampled", "output_folder")
+    self.addLink("execution_log", "output_folder")
+
+    self.addLink(None, "parc", self.update_output_type)
+
+    # Set user levels for advanced options
+    self.setUserLevel(2, "parc", "robust", "fast", "crop", "threads", "cpu", "v1", "overwrite")
+
+
+def update_output_type(self, parc):
+    seg_type = self.signature["segmentation"].type
+
+    if parc and str(seg_type) != "SynthSeg parcellation":
+        self.signature["segmentation"].type = WriteDiskItem("SynthSeg parcellation", default_format).type
+    elif not parc and str(seg_type) != "SynthSeg segmentation":
+        self.signature["segmentation"].type = WriteDiskItem("SynthSeg segmentation", default_format).type
+    else:
+        return
+
+    self.changeSignature(self.signature)
+    self.update_output()
+
+
+def update_output(self, *_):
+    if self.output_folder:
+        return self.signature["segmentation"].findValue(self.output_folder.hierarchyAttributes())
+    return
+
+
+def execution(self, context):
+    # Check if output folder is empty
+    output_dir = self.output_folder.fullPath()
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Check if directory is empty
+    if os.listdir(output_dir):
+        if self.overwrite:
+            shutil.rmtree(output_dir)
+            os.makedirs(output_dir, exist_ok=True)
+        else:
+            context.error(
+                f"Output directory '{output_dir}' is not empty. SynthSeg has already been launched for this subjet and timepoint. "
+                "Please remove these results or choose overwrtie option to do so."
+            )
+            raise AttributeError()
+
+    context.runProcess(
+        "RunSynthSeg_generic",
+        t1mri=self.t1mri,
+        output_folder=self.output_folder,
+        segmentation=self.segmentation,
+        volumes_csv=self.volumes_csv,
+        qc_csv=self.qc_csv,
+        posterior=self.posterior,
+        resampled=self.resampled,
+        execution_log=self.execution_log,
+        parc=self.parc,
+        robust=self.robust,
+        fast=self.fast,
+        crop=self.crop,
+        threads=self.threads,
+        cpu=self.cpu,
+        v1=self.v1,
+        overwrite=self.overwrite,
+    )

--- a/brainvisa/toolboxes/freesurfer/processes/Tools/RunSynthSeg_generic.py
+++ b/brainvisa/toolboxes/freesurfer/processes/Tools/RunSynthSeg_generic.py
@@ -86,8 +86,7 @@ def execution(self, context):
             raise AttributeError()
 
     # Build command
-    output_file = os.path.join(output_dir, "segmentation.nii.gz")
-    cmd = ["mri_synthseg", "--i", self.t1mri, "--o", output_file]
+    cmd = ["mri_synthseg", "--i", self.t1mri, "--o", self.segmentation]
 
     # Add optional flags
     if self.parc:
@@ -103,7 +102,7 @@ def execution(self, context):
     if self.threads:
         cmd.extend(["--threads", str(self.threads)])
     if self.crop:
-        cmd.extend(["--crop", self.crop])
+        cmd.extend(["--crop"] + self.crop.split())
     if self.volumes_csv:
         cmd.extend(["--vol", self.volumes_csv])
     if self.qc_csv:
@@ -114,6 +113,7 @@ def execution(self, context):
         cmd.extend(["--resample", self.resampled])
 
     if self.execution_json:
+    if self.execution_log:
         exec_json = {
             "process": "synthSeg",
             "parameters": {
@@ -122,22 +122,23 @@ def execution(self, context):
                 },
                 "outputs": {
                     "segmentation": self.segmentation.fullPath(),
-                    "volumes_csv": self.volumes_csv.fullPath(),
-                    "qc_csv": self.qc_csv.fullPath(),
-                    "posterior": self.posterior.fullPath(),
+                    "volumes_csv": self.volumes_csv.fullPath() if self.volumes_csv else None,
+                    "qc_csv": self.qc_csv.fullPath() if self.qc_csv else None,
+                    "posterior": self.posterior.fullPath() if self.posterior else None,
+                    "resampled": self.resampled.fullPath() if self.resampled else None,
                 },
                 "robust": self.robust,
                 "parc": self.parc,
                 "fast": self.fast,
-                "crop": self.proc,
+                "crop": self.crop,
                 "v1": self.v1,
                 "threads": self.threads,
                 "cpu": self.cpu,
-                "command": self
+                "command": " ".join(str(c) for c in cmd)
             }
         }
 
-        with open(self.execution_json.fullPath(), "w") as json_file:
+        with open(self.execution_log.fullPath(), "w") as json_file:
             json.dump(exec_json, json_file)
     
     launchFreesurferCommand(context, None, *cmd)

--- a/brainvisa/toolboxes/freesurfer/processes/Tools/RunSynthSeg_generic.py
+++ b/brainvisa/toolboxes/freesurfer/processes/Tools/RunSynthSeg_generic.py
@@ -1,0 +1,143 @@
+import os
+import shutil
+import json
+from pathlib import Path
+
+from brainvisa.processes import Boolean, Integer, ReadDiskItem, Signature, String, WriteDiskItem
+from freesurfer.brainvisaFreesurfer import launchFreesurferCommand, testFreesurferCommand
+
+name = "Run SynthSeg"
+userLevel = 1
+
+synthseg_options = "SynthSeg options"
+optional_outputs = "Optional outputs"
+
+default_format = ["gz compressed NIFTI-1 image", "NIFTI-1 image"]
+
+# fmt: off
+signature = Signature(
+    # Input
+    "t1mri", ReadDiskItem("4D Volume", default_format),
+
+    # Output folder
+    "output_folder", WriteDiskItem("Directory", "Directory"),
+
+    # Main output
+    "segmentation", WriteDiskItem("4D Volume", default_format),
+
+    # Optional outputs
+    "volumes_csv", WriteDiskItem("CSV file", "CSV file", section=optional_outputs),
+    "qc_csv", WriteDiskItem("CSV file", "CSV file", section=optional_outputs),
+    "posterior", WriteDiskItem("4D Volume", default_format,
+                               section=optional_outputs),
+    "resampled", WriteDiskItem("4D Volume", default_format,
+                               section=optional_outputs),
+    "execution_log", WriteDiskItem("JSON file", "JSON file", section=optional_outputs),
+
+    # SynthSeg options
+    "parc", Boolean(section=synthseg_options),
+    "robust", Boolean(section=synthseg_options),
+    "fast", Boolean(section=synthseg_options),
+    "crop", String(section=synthseg_options),
+    "threads", Integer(section=synthseg_options),
+    "cpu", Boolean(section=synthseg_options),
+    "v1", Boolean(section=synthseg_options),
+    "overwrite", Boolean(section=synthseg_options)
+)
+# fmt: on
+
+
+def validation():
+    testFreesurferCommand()
+
+
+def initialization(self):
+    # Set defaults matching SynthSeg
+    self.threads = 1
+    self.cpu = False
+    self.robust = False
+    self.fast = False
+    self.parc = False
+    self.v1 = False
+    self.overwrite = False
+
+    # Make optional outputs optional
+    self.setOptional("volumes_csv", "qc_csv", "posterior", "resampled", "crop")
+
+    # Set user levels for advanced options
+    self.setUserLevel(2, "parc", "robust", "fast", "crop", "threads", "cpu", "v1", "overwrite")
+
+
+def execution(self, context):
+    # Check if output folder is empty
+    output_dir = self.output_folder.fullPath()
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Check if directory is empty
+    if os.listdir(output_dir):
+        if self.overwrite:
+            shutil.rmtree(output_dir)
+            os.makedirs(output_dir, exist_ok=True)
+        else:
+            context.error(
+                f"Output directory '{output_dir}' is not empty. SynthSeg has already been launched for this subjet and timepoint. "
+                "Please remove these results or choose overwrtie option to do so."
+            )
+            raise AttributeError()
+
+    # Build command
+    output_file = os.path.join(output_dir, "segmentation.nii.gz")
+    cmd = ["mri_synthseg", "--i", self.t1mri, "--o", output_file]
+
+    # Add optional flags
+    if self.parc:
+        cmd.append("--parc")
+    if self.robust:
+        cmd.append("--robust")
+    if self.fast:
+        cmd.append("--fast")
+    if self.cpu:
+        cmd.append("--cpu")
+    if self.v1:
+        cmd.append("--v1")
+    if self.threads:
+        cmd.extend(["--threads", str(self.threads)])
+    if self.crop:
+        cmd.extend(["--crop", self.crop])
+    if self.volumes_csv:
+        cmd.extend(["--vol", self.volumes_csv])
+    if self.qc_csv:
+        cmd.extend(["--qc", self.qc_csv])
+    if self.posterior:
+        cmd.extend(["--post", self.posterior])
+    if self.resampled:
+        cmd.extend(["--resample", self.resampled])
+
+    if self.execution_json:
+        exec_json = {
+            "process": "synthSeg",
+            "parameters": {
+                "inputs": {
+                    "t1mri": self.t1mri.fullPath()
+                },
+                "outputs": {
+                    "segmentation": self.segmentation.fullPath(),
+                    "volumes_csv": self.volumes_csv.fullPath(),
+                    "qc_csv": self.qc_csv.fullPath(),
+                    "posterior": self.posterior.fullPath(),
+                },
+                "robust": self.robust,
+                "parc": self.parc,
+                "fast": self.fast,
+                "crop": self.proc,
+                "v1": self.v1,
+                "threads": self.threads,
+                "cpu": self.cpu,
+                "command": self
+            }
+        }
+
+        with open(self.execution_json.fullPath(), "w") as json_file:
+            json.dump(exec_json, json_file)
+    
+    launchFreesurferCommand(context, None, *cmd)

--- a/brainvisa/toolboxes/freesurfer/types/synthseg.py
+++ b/brainvisa/toolboxes/freesurfer/types/synthseg.py
@@ -1,0 +1,7 @@
+include('builtin')
+
+FileType('SynthSeg volumes', 'CSV file')
+FileType('SynthSeg segmentation', 'Label volume')
+FileType('SynthSeg parcellation', 'Label volume')
+FileType('SynthSeg execution log', 'Any Type', 'JSON file')
+FileType('SynthSeg resampled', 'Raw T1 MRI')


### PR DESCRIPTION
Attempt to add synthSeg wrapping in brainvisa with saving all the results in a "synthSeg" folder.

The "runSynthSeg_generic" allows launching on any data without brainvisa database, and "runSynthSeg" use brainvisa database as input and to fill the outputs.

For now I do not permit to launch synthSeg if it has already ran, in order to avoid erasing data that ran with different parameters.
I added the save of a JSON file to keep parameters used for synthSeg.